### PR TITLE
Create a deadline for cronjob

### DIFF
--- a/helm/route53-manager-chart/templates/03-cronjob.yaml
+++ b/helm/route53-manager-chart/templates/03-cronjob.yaml
@@ -8,6 +8,8 @@ spec:
   jobTemplate:
     spec:
       successfulJobsHistoryLimit: 2
+      # Job timeout
+      activeDeadlineSeconds: 600
       template:
         spec:
           volumes:

--- a/helm/route53-manager-chart/templates/03-cronjob.yaml
+++ b/helm/route53-manager-chart/templates/03-cronjob.yaml
@@ -5,9 +5,10 @@ metadata:
   namespace: giantswarm
 spec:
   schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
-      successfulJobsHistoryLimit: 2
       # Job timeout
       activeDeadlineSeconds: 600
       template:


### PR DESCRIPTION
If we don´t have a deadline a pod can last forever and another one will be created then there will be tones of pods in the cluster

Towards: https://github.com/giantswarm/giantswarm/issues/5841