### PR TITLE
reduce TTL for DNS records to 30s

### DIFF
--- a/pkg/recordset/stack_template.go
+++ b/pkg/recordset/stack_template.go
@@ -21,7 +21,7 @@ Resources:
       HostedZoneId: {{ .HostedZoneID }}
       Name: 'ingress.{{ .ClusterName }}.{{ .HostedZoneName }}'
       Type: CNAME
-      TTL: '900'
+      TTL: '30'
       ResourceRecords:
       - {{ .IngressELBDNS }}
 
@@ -31,7 +31,7 @@ Resources:
       HostedZoneId: {{ .HostedZoneID }}
       Name: '*.{{ .ClusterName }}.{{ .HostedZoneName }}'
       Type: CNAME
-      TTL: '900'
+      TTL: '30'
       ResourceRecords:
       - {{ .IngressELBDNS }}
 
@@ -41,7 +41,7 @@ Resources:
       HostedZoneId: {{ .HostedZoneID }}
       Name: 'api.{{ .ClusterName }}.{{ .HostedZoneName }}'
       Type: CNAME
-      TTL: '900'
+      TTL: '30'
       ResourceRecords:
       - {{ .APIELBDNS }}
 
@@ -51,7 +51,7 @@ Resources:
       HostedZoneId: {{ .HostedZoneID }}
       Name: 'etcd.{{ .ClusterName }}.{{ .HostedZoneName }}'
       Type: CNAME
-      TTL: '900'
+      TTL: '30'
       ResourceRecords:
       - {{ .EtcdInstanceDNS }}
 `


### PR DESCRIPTION
the previous DNS TTL 900 sec is incredibly long for updates this can often break/slow the update of TC