### PR TITLE
Fix source stack regex match

### DIFF
--- a/pkg/recordset/recordset.go
+++ b/pkg/recordset/recordset.go
@@ -18,7 +18,7 @@ const (
 	// of Tenant Clusters below Giant Swarm Release version 10.0.0, aka legacy
 	// clusters, aka non Node Pool clusters.
 	legacySourceStackNamePattern = "cluster-.*-guest-main"
-	sourceStackNamePattern       = "cluster-.*-tccp"
+	sourceStackNamePattern       = "cluster-.*-tccp$"
 	targetStackNamePattern       = "cluster-.*-guest-recordsets"
 )
 


### PR DESCRIPTION
I've found this error in logs after merging this PR https://github.com/giantswarm/route53-manager/pull/24

```
{"caller":"github.com/giantswarm/route53-manager/pkg/recordset/recordset.go:324","level":"error","message":"failed to get source stack data `9krr8`","stack":"[{/go/src/github.com/giantswarm/route53-manager/pkg/recordset/stack_templ
ate.go:123: } {/go/src/github.com/giantswarm/route53-manager/pkg/recordset/stack_template.go:152: } {LoadBalancerNotFound: There is no ACTIVE Load Balancer named '9krr8-api'\n\tstatus code: 400, request id: 558ec4a1-230b-4ea4-b879-
87f9e7497ad8}]","time":"2019-12-23T15:25:10.8465+00:00"}  
```

Turned out this expression https://github.com/giantswarm/route53-manager/blob/master/pkg/recordset/recordset.go#L21 matches both `cluster-9krr8-tccp` and `cluster-9krr8-tccpi` (initializer stack), but second stack doesn't have resources we're looking for. 

This PR fixes regex expression