### PR TITLE
add-eni-records-sets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,6 @@ workflows:
             - build-route53-manager
           # Needed to trigger job only on git tag.
           filters:
-            branches:
-              only: master
             tags:
               only: /^v.*/
 
@@ -50,20 +48,6 @@ workflows:
           requires:
             - push-route53-manager-to-quay
           # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-      # Push to Aliyun should execute without manual approval on master.
-      - architect/push-to-docker-legacy:
-          name: push-route53-manager-to-aliyun
-          context: architect
-          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/route53-manager"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          requires:
-            - build-route53-manager
-          # Needed to trigger job only on merge to master.
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,32 +54,9 @@ workflows:
             tags:
               only: /^v.*/
 
-      - hold-push-route53-manager-to-aliyun-pr:
-          type: approval
-          requires:
-            - build-route53-manager
-          # Needed to prevent job from being triggered on master branch.
-          filters:
-            branches:
-              ignore: master
-
-      - architect/push-to-docker-legacy:
-          name: push-route53-manager-to-aliyun-pr
-          context: architect
-          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/route53-manager"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          # Push to Aliyun should execute for non-master branches only once manually approved.
-          requires:
-            - hold-push-route53-manager-to-aliyun-pr
-          # Needed to prevent job being triggered for master branch.
-          filters:
-            branches:
-              ignore: master
-
       # Push to Aliyun should execute without manual approval on master.
       - architect/push-to-docker-legacy:
-          name: push-route53-manager-to-aliyun-master
+          name: push-route53-manager-to-aliyun
           context: architect
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/route53-manager"
           username_envar: "ALIYUN_USERNAME"
@@ -88,8 +65,8 @@ workflows:
             - build-route53-manager
           # Needed to trigger job only on merge to master.
           filters:
-            branches:
-              only: master
+            tags:
+              only: /^v.*/
 
       - architect/push-to-app-collection:
           name: push-route53-manager-to-aws-app-collection

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,6 +28,7 @@ type SourceInterface interface {
 	StackDescribeLister
 	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
 	DescribeLoadBalancers(*elb.DescribeLoadBalancersInput) (*elb.DescribeLoadBalancersOutput, error)
+	DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error)
 }
 
 type TargetInterface interface {

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -1,0 +1,19 @@
+package key
+
+import "fmt"
+
+const (
+	TagCluster = "giantswarm.io/cluster"
+)
+
+func BaseDomain(clusterID string, hostedZoneName string) string {
+	return fmt.Sprintf("%s.%s", clusterID, hostedZoneName)
+}
+
+func EtcdENIDNSName(baseDomain string, index int) string {
+	return fmt.Sprintf("etcd%d.%s", index+1, baseDomain)
+}
+
+func EtcdEniResourceName(index int) string {
+	return fmt.Sprintf("EtcdEniDNSRecordSet%d", index+1)
+}

--- a/pkg/recordset/mock_test.go
+++ b/pkg/recordset/mock_test.go
@@ -103,6 +103,17 @@ func (s *sourceClientMock) DescribeLoadBalancers(*elb.DescribeLoadBalancersInput
 
 	return output, nil
 }
+func (s *sourceClientMock) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	output := &ec2.DescribeNetworkInterfacesOutput{
+		NetworkInterfaces: []*ec2.NetworkInterface{
+			&ec2.NetworkInterface{
+				PrivateIpAddress: aws.String("10.1.0.1"),
+			},
+		},
+	}
+
+	return output, nil
+}
 
 type targetClientMock struct {
 	createdStacks []string

--- a/pkg/recordset/recordset.go
+++ b/pkg/recordset/recordset.go
@@ -100,7 +100,14 @@ type sourceStackData struct {
 	IngressELBDNS   string
 	IsLegacyCluster bool
 	APIELBDNS       string
-	EtcdInstanceDNS string
+	EtcdELBDNS      string
+	EtcdEniList     []EtcdEni
+}
+
+type EtcdEni struct {
+	DNSName   string
+	IPAddress string
+	Name      string
 }
 
 var (
@@ -571,6 +578,9 @@ func getManagedRecordSets(clusterID, baseDomain string) []string {
 		fmt.Sprintf("\\052.%s.%s.", clusterID, baseDomain), // \\052 - `*` wildcard record
 		fmt.Sprintf("api.%s.%s.", clusterID, baseDomain),
 		fmt.Sprintf("etcd.%s.%s.", clusterID, baseDomain),
+		fmt.Sprintf("etcd1.%s.%s.", clusterID, baseDomain),
+		fmt.Sprintf("etcd2.%s.%s.", clusterID, baseDomain),
+		fmt.Sprintf("etcd3.%s.%s.", clusterID, baseDomain),
 		fmt.Sprintf("ingress.%s.%s.", clusterID, baseDomain),
 	}
 }

--- a/pkg/recordset/stack_template.go
+++ b/pkg/recordset/stack_template.go
@@ -200,10 +200,6 @@ func (m *Manager) getEniList(clusterID string, baseDomain string) ([]EtcdEni, er
 		return nil, microerror.Mask(err)
 	}
 
-	if len(output.NetworkInterfaces) == 0 {
-		return nil, microerror.Mask(tooFewResultsError)
-	}
-
 	for i, nic := range output.NetworkInterfaces {
 		e := EtcdEni{
 			DNSName:   key.EtcdENIDNSName(baseDomain, i),

--- a/pkg/recordset/stack_template.go
+++ b/pkg/recordset/stack_template.go
@@ -3,14 +3,14 @@ package recordset
 import (
 	"bytes"
 	"fmt"
-	"github.com/giantswarm/route53-manager/pkg/key"
-	"html/template"
+	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/route53-manager/pkg/key"
 )
 
 const (
@@ -60,7 +60,7 @@ Resources:
       - {{ .EtcdELBDNS }}
 
   {{ $hz := .HostedZoneID }}
-  {{- range $data.EtcdEniList }}
+  {{- range .EtcdEniList }}
   {{ .Name }}:
     Type: AWS::Route53::RecordSet
     Properties:

--- a/pkg/recordset/stack_template.go
+++ b/pkg/recordset/stack_template.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/giantswarm/microerror"
+
 	"github.com/giantswarm/route53-manager/pkg/key"
 )
 


### PR DESCRIPTION
* add etcd ENI records sets for the tccpn stack required for HA masters
* migrate etcd DNS record from master instance to ELB 
* change circle config to push to china always ( there is no point of having hold button, route53-manager is only used in china so testing it anywhere else is useless and  need to click hold button every test is annoying)