### PR TITLE
fix-if-route53-enabled

### DIFF
--- a/helm/route53-manager/templates/01-secret.yaml
+++ b/helm/route53-manager/templates/01-secret.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
+{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/helm/route53-manager/templates/02-configmap.yaml
+++ b/helm/route53-manager/templates/02-configmap.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
+{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/route53-manager/templates/03-serviceaccount.yaml
+++ b/helm/route53-manager/templates/03-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
+{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/route53-manager/templates/04-rbac.yaml
+++ b/helm/route53-manager/templates/04-rbac.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
+{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/route53-manager/templates/05-psp.yaml
+++ b/helm/route53-manager/templates/05-psp.yaml
@@ -1,7 +1,9 @@
 {{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
-metadata: name: {{ .Values.name }}-psp spec:
+metadata:
+  name: {{ .Values.name }}-psp
+spec:
   privileged: false
   fsGroup:
     rule: MustRunAs

--- a/helm/route53-manager/templates/05-psp.yaml
+++ b/helm/route53-manager/templates/05-psp.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
+{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata: name: {{ .Values.name }}-psp spec:

--- a/helm/route53-manager/templates/06-cronjob.yaml
+++ b/helm/route53-manager/templates/06-cronjob.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
+{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:


### PR DESCRIPTION
 route53-manager should be deployed when route53 is not enabled in the AWS