### PR TITLE
Fix clusterrole template to pass openapi validation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.8.14
+  architect: giantswarm/architect@0.10.0
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- Fix clusterrole template to pass openapi validation.
+
+## [v1.0.0] 2020-06-18
+
+### Added
+
+- Initial release to control plane catalog.
+
+[Unreleased]: https://github.com/giantswarm/route53-manager/compare/v1.0.0..HEAD
+
+[v1.0.0]: https://github.com/giantswarm/route53-manager/releases/tag/v1.0.0

--- a/helm/route53-manager/templates/04-rbac.yaml
+++ b/helm/route53-manager/templates/04-rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.name }}-psp
-  rules:
+rules:
   - apiGroups:
       - extensions
     resources:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11969

```
kubectl -n giantswarm get app route53-manager-unique -o yaml | yq .status.release
{
  "lastDeployed": null,
  "reason": "helm validation error: (unable to build kubernetes objects from release manifest: error validating \"\": error validating data: ValidationError(ClusterRole.metadata): unknown field \"rules\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta)",
  "status": "validation-failed"
}
```