### PR TITLE
Adding empty values for configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent empty resources on other AWS installations with route53 support.
+
 ## [1.0.1] - 2020-07-08
 
 ### Fixed

--- a/helm/route53-manager/templates/02-configmap.yaml
+++ b/helm/route53-manager/templates/02-configmap.yaml
@@ -4,11 +4,9 @@ metadata:
   name: route53-manager-configmap
   namespace: giantswarm
 data:
-{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
   config.yaml: |
+{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
     service:
       installation:
         name: '{{ .Values.Installation.V1.Name }}'
-{{ else }}
-  empty: ""
 {{ end }}

--- a/helm/route53-manager/templates/02-configmap.yaml
+++ b/helm/route53-manager/templates/02-configmap.yaml
@@ -1,12 +1,14 @@
-{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: route53-manager-configmap
   namespace: giantswarm
 data:
+{{ if not .Values.Installation.V1.Provider.AWS.Route53.Enabled }}
   config.yaml: |
     service:
       installation:
         name: '{{ .Values.Installation.V1.Name }}'
+{{ else }}
+  empty: ""
 {{ end }}


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/12582

Except for China CPs, we get `no objects visited` helm errors from other AWS CPs.
Adding fake configmap values would help in this case. 