### PR TITLE
exclude-capi-nodes-from-eni-etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add  EC2 ENI filter to filter out CAPI based ENIs. THis is encessery during migration.
+
 ## [1.4.0] - 2024-05-02
 
 ### Added

--- a/pkg/recordset/stack_template.go
+++ b/pkg/recordset/stack_template.go
@@ -193,6 +193,12 @@ func (m *Manager) getEniList(clusterID string, baseDomain string) ([]EtcdEni, er
 					aws.String(clusterID),
 				},
 			},
+			{
+				Name: aws.String("tag:aws:cloudformation:stack-name"),
+				Values: []*string{
+					aws.String(fmt.Sprintf("cluster-%s-tccpn", clusterID)),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
add an extra filter to exclude ENIs from CAPI control plane nodes, necessary for migration

https://github.com/giantswarm/roadmap/issues/3481
